### PR TITLE
urldecode query string before splitting into gist id and filename

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,9 +167,9 @@
       }
 
       // 2. get gist id and file name
-      query = query.split('/');
+      query = decodeURIComponent(query).split('/');
       var gistId = query[0].split(/[=&]/)[0];
-      var fileName = decodeURIComponent(query[1] || '');
+      var fileName = query[1] || '';
 
       // 3. write data to inputs
       document.getElementById('gist_id').value = gistId;


### PR DESCRIPTION
Some tools will urlencode a /, which then breaks the link.